### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Provides really simple BLE advertiser
 paragraph=
 category=Communication
 url=https://github.com/lucascoelhof/ESP32BleAdvertise
-architectures=arduino-esp32
+architectures=esp32,arduino-esp32


### PR DESCRIPTION
The previous `architectures` value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library ESP32BleAdvertise claims to run on (arduino-esp32) architecture(s) and may be incompatible with your current board which runs on (esp32) architecture(s).
```
The previous architectures value caused the library's examples to be placed under the **File > Examples > INCOMPATIBLE** menu.

Although `esp32` is the correct architectures value for the official Espressif ESP32 core for Arduino, if the [installation instructions](https://github.com/espressif/arduino-esp32#installation-instructions) are not followed correctly the architectures value will instead be `arduino-esp32` and so I have left the previous `architectures` value in library.properties as well.